### PR TITLE
fix bad dependencies on 0.8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,11 +10,11 @@
   "repository": "https://github.com/Polymer/core-pages/tree/0.8-preview",
   "dependencies": {
     "polymer": "Polymer/polymer#0.8-preview",
-    "polymer": "Polymer/core-resizable#0.8-preview",
-    "polymer": "Polymer/core-selector#0.8-preview"
+    "core-resizable": "Polymer/core-resizable#0.8-preview",
+    "core-selector": "Polymer/core-selector#0.8-preview"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#^1.1.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#master"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#0.6.0"
   }
 }


### PR DESCRIPTION
bower.json had the wrong names for the `core-resizable` and `core-selector` dependencies.